### PR TITLE
Fix bug with expecting anaconda's directory not to change

### DIFF
--- a/utilities/entrypoint.sh
+++ b/utilities/entrypoint.sh
@@ -17,5 +17,5 @@ if ! [ $(id -u) = 0 ]; then
 	fi
 fi
 # Run command
-[ "$(pwd)" != "/home/anaconda" ] || cd ~
+pwd | grep -qvE "^\/home\/\.?anaconda$" || cd ~
 "$@"

--- a/utilities/shell_intercept.sh
+++ b/utilities/shell_intercept.sh
@@ -10,14 +10,13 @@ conda activate
 if ! [ $(id -u) = 0 ]; then
 	# Default to the anaconda user
 	ORIG_USER=anaconda
-	ORIG_HOME=/home/anaconda
 	# Detect if renaming user
 	if [ -z "$NEW_USER" ]; then
 		NEW_USER=$ORIG_USER
 	fi
 	# Detect if 'moving' home dir
 	if [ -z "$NEW_HOME" ]; then
-		NEW_HOME=$ORIG_HOME
+		NEW_HOME=$HOME
 	fi
 	# Fix UID/GID (for permissions), rename user, and rename home as appropriate
 	CURR_DIR=$(pwd) # this is necessary to prevent collisions if standing in directory


### PR DESCRIPTION
`djlabhub` for instance needs this. Also, adds hidden `anaconda` directory to be handled on shell.